### PR TITLE
Setting path with working_dir / Fixes unit tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 2.0.2
-* Fixed: removed 'os.chdir' calls that were causing os errors
+* Fixed: removed 'os.chdir' calls that were causing os.chdir errors
 * https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-15#commands-accepting-a-configuration-directory-argument
 * Fixed: unit tests
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2.0.2
+* Fixed: removed 'os.chdir' calls that were causing os errors
+* https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-15#commands-accepting-a-configuration-directory-argument
+* Fixed: unit tests
+
 ## 2.0.1
 * Fixed: apply for non default terraform binary path
 

--- a/actions/apply.py
+++ b/actions/apply.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 from dda_python_terraform import IsFlagged
 
@@ -21,7 +20,7 @@ class Apply(action.TerraformBaseAction):
         Returns:
         - dict: Terraform output command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.state = state_file_path
         self.terraform.targets = target_resources
         self.terraform.terraform_bin_path = terraform_exec
@@ -30,7 +29,6 @@ class Apply(action.TerraformBaseAction):
         self.set_semantic_version()
 
         return_code, stdout, stderr = self.terraform.apply(
-            plan_path,
             skip_plan=True,
             auto_approve=IsFlagged,
             capture_output=False,

--- a/actions/create_workspace.py
+++ b/actions/create_workspace.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -15,10 +14,10 @@ class CreateWorkspace(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace new command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace("new", workspace,
-                                                                '-no-color', 
-                                                                raise_on_error=False)
+                                                               '-no-color',
+                                                               raise_on_error=False)
         return self.check_result(return_code, stdout, stderr)

--- a/actions/delete_workspace.py
+++ b/actions/delete_workspace.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -15,7 +14,7 @@ class DeleteWorkspace(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace delete command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace(

--- a/actions/destroy.py
+++ b/actions/destroy.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 from dda_python_terraform import IsFlagged
 
@@ -21,12 +20,11 @@ class Destroy(action.TerraformBaseAction):
         Returns:
         - dict: Terraform destroy command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         self.terraform.targets = target_resources
         return_code, stdout, stderr = self.terraform.destroy(
-            plan_path,
             var_file=variable_files,
             var=variable_dict,
             state=state_file_path,

--- a/actions/import_object.py
+++ b/actions/import_object.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -21,7 +20,7 @@ class Import(action.TerraformBaseAction):
         Returns:
         - dict: Terraform destroy command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.import_cmd(

--- a/actions/init.py
+++ b/actions/init.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 from dda_python_terraform import IsFlagged, IsNotFlagged
 
@@ -17,12 +16,11 @@ class Init(action.TerraformBaseAction):
         Returns:
         - dict: Terraform init command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
 
         return_code, stdout, stderr = self.terraform.init(
-            plan_path,
             backend_config=backend,
             capture_output=False,
             upgrade=IsFlagged if upgrade else IsNotFlagged,

--- a/actions/list_workspaces.py
+++ b/actions/list_workspaces.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -14,7 +13,7 @@ class ListWorkspaces(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace list command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace(

--- a/actions/output.py
+++ b/actions/output.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -14,7 +13,7 @@ class Output(action.TerraformBaseAction):
         Returns:
         - dict: Terraform output command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return self.terraform.output(state=state_file_path)

--- a/actions/plan.py
+++ b/actions/plan.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -20,7 +19,7 @@ class Plan(action.TerraformBaseAction):
         Returns:
         - dict: Terraform output command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.state = state_file_path
         self.terraform.targets = target_resources
         self.terraform.terraform_bin_path = terraform_exec
@@ -28,7 +27,6 @@ class Plan(action.TerraformBaseAction):
         self.terraform.variables = variable_dict
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.plan(
-            plan_path,
             capture_output=False,
             raise_on_error=False)
 

--- a/actions/select_workspace.py
+++ b/actions/select_workspace.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -15,7 +14,7 @@ class SelectWorkspace(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace select command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace(

--- a/actions/show.py
+++ b/actions/show.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -14,7 +13,7 @@ class Show(action.TerraformBaseAction):
         Returns:
         - dict: Terraform show command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.show(

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 2.0.1
+version: 2.0.2
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:

--- a/tests/test_action_apply.py
+++ b/tests/test_action_apply.py
@@ -12,10 +12,10 @@ class PlanTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Apply)
 
-    @mock.patch("list_workspaces.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.apply")
-    def test_run(self, mock_apply, mock_check_result, mock_chdir):
+    def test_run(self, mock_apply, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -30,9 +30,8 @@ class PlanTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_apply.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -48,12 +47,11 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_apply.assert_called_with(
-            test_plan_path,
             skip_plan=True,
             auto_approve=IsFlagged,
-            capture_output=False
+            capture_output=False,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(
             test_return_code,

--- a/tests/test_action_delete_workspace.py
+++ b/tests/test_action_delete_workspace.py
@@ -11,10 +11,10 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, DeleteWorkspace)
 
-    @mock.patch("delete_workspace.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result, mock_chdir):
+    def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -26,9 +26,8 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -39,8 +38,7 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_workspace.assert_called_with("workspace")
         action.terraform.workspace.assert_called_with("delete", "-force", test_workspace,
-                                                      "-no-color")
+                                                      "-no-color", raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_init.py
+++ b/tests/test_action_init.py
@@ -12,10 +12,10 @@ class InitTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Init)
 
-    @mock.patch("list_workspaces.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_false(self, mock_init, mock_check_result, mock_chdir):
+    def test_run_upgrade_false(self, mock_init, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -28,9 +28,8 @@ class InitTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_init.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -41,19 +40,18 @@ class InitTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
-            test_plan_path,
             backend_config=test_backend,
             capture_output=False,
-            upgrade=IsNotFlagged
+            upgrade=IsNotFlagged,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
-    @mock.patch("list_workspaces.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_true(self, mock_init, mock_check_result, mock_chdir):
+    def test_run_upgrade_true(self, mock_init, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -66,9 +64,8 @@ class InitTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_init.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -79,19 +76,18 @@ class InitTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
-            test_plan_path,
             backend_config=test_backend,
             capture_output=False,
-            upgrade=IsFlagged
+            upgrade=IsFlagged,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
-    @mock.patch("list_workspaces.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_none(self, mock_init, mock_check_result, mock_chdir):
+    def test_run_upgrade_none(self, mock_init, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -104,9 +100,8 @@ class InitTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_init.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -117,11 +112,10 @@ class InitTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
-            test_plan_path,
             backend_config=test_backend,
             capture_output=False,
-            upgrade=IsNotFlagged
+            upgrade=IsNotFlagged,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_list_workspaces.py
+++ b/tests/test_action_list_workspaces.py
@@ -11,10 +11,10 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, ListWorkspaces)
 
-    @mock.patch("list_workspaces.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result, mock_chdir):
+    def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -25,9 +25,8 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -38,7 +37,6 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_workspace.assert_called_with("workspace")
-        action.terraform.workspace.assert_called_with("list")
+        action.terraform.workspace.assert_called_with("list", raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_output.py
+++ b/tests/test_action_output.py
@@ -11,9 +11,9 @@ class OutputTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Output)
 
-    @mock.patch("output.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.Terraform.output")
-    def test_run_state_file(self, mock_output, mock_chdir):
+    def test_run_state_file(self, mock_output, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -24,7 +24,7 @@ class OutputTestCase(TerraformBaseActionTestCase):
         expected_result = "result"
         mock_output.return_value = expected_result
 
-        mock_chdir.return_value = "success"
+        mock_version.return_value = '1.1.1'
 
         # Execute the run function
         result = action.run(test_plan_path, test_state_file_path, test_terraform_exec)
@@ -33,12 +33,11 @@ class OutputTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertTrue(mock_output.called)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_output.assert_called_with(state=test_state_file_path)
 
-    @mock.patch("output.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.Terraform.output")
-    def test_run_no_state_file(self, mock_output, mock_chdir):
+    def test_run_no_state_file(self, mock_output, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -48,7 +47,7 @@ class OutputTestCase(TerraformBaseActionTestCase):
         expected_result = "result"
         mock_output.return_value = expected_result
 
-        mock_chdir.return_value = "success"
+        mock_version.return_value = '1.1.1'
 
         # Execute the run function
         result = action.run(test_plan_path, None, test_terraform_exec)
@@ -57,5 +56,4 @@ class OutputTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertTrue(mock_output.called)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_output.assert_called_with(state=None)

--- a/tests/test_action_plan.py
+++ b/tests/test_action_plan.py
@@ -11,10 +11,10 @@ class PlanTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Plan)
 
-    @mock.patch("list_workspaces.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
-    def test_run(self, mock_plan, mock_check_result, mock_chdir):
+    def test_run(self, mock_plan, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -29,9 +29,8 @@ class PlanTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_plan.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -47,8 +46,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_chdir.assert_called_with(test_plan_path)
-        mock_plan.assert_called_with(test_plan_path, capture_output=False)
+        mock_plan.assert_called_with(capture_output=False, raise_on_error=False)
         mock_check_result.assert_called_with(
             test_return_code,
             test_stdout,
@@ -57,10 +55,10 @@ class PlanTestCase(TerraformBaseActionTestCase):
             valid_return_codes=[0, 2]
         )
 
-    @mock.patch("list_workspaces.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
-    def test_run_exit_code_2(self, mock_plan, mock_check_result, mock_chdir):
+    def test_run_exit_code_2(self, mock_plan, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -75,9 +73,8 @@ class PlanTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_plan.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -93,8 +90,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_chdir.assert_called_with(test_plan_path)
-        mock_plan.assert_called_with(test_plan_path, capture_output=False)
+        mock_plan.assert_called_with(capture_output=False, raise_on_error=False)
         mock_check_result.assert_called_with(
             test_return_code,
             test_stdout,

--- a/tests/test_action_select_workspace.py
+++ b/tests/test_action_select_workspace.py
@@ -11,10 +11,10 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, SelectWorkspace)
 
-    @mock.patch("select_workspace.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result, mock_chdir):
+    def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -26,9 +26,8 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -39,7 +38,9 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_workspace.assert_called_with("workspace")
-        action.terraform.workspace.assert_called_with("select", test_workspace, "-no-color")
+        action.terraform.workspace.assert_called_with("select",
+                                                      test_workspace,
+                                                      "-no-color",
+                                                      raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_show.py
+++ b/tests/test_action_show.py
@@ -11,10 +11,10 @@ class ShowTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Show)
 
-    @mock.patch("show.os.chdir")
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_show, mock_check_result, mock_chdir):
+    def test_run(self, mock_show, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -25,9 +25,8 @@ class ShowTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.show.return_value = test_return_code, test_stdout, test_stderr
-
-        mock_chdir.return_value = "success"
 
         expected_result = "result"
         mock_check_result.return_value = expected_result
@@ -38,7 +37,6 @@ class ShowTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
         mock_show.assert_called_with("show")
-        action.terraform.show.assert_called_with("-no-color")
+        action.terraform.show.assert_called_with("-no-color", raise_on_error=False)


### PR DESCRIPTION

Removing calls to os.chdir and setting path to working_dir

( https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-15#commands-accepting-a-configuration-directory-argument )

Fixes 'Too many command line arguments. Did you mean to use -chdir?' errors

Also fixes unit tests
